### PR TITLE
Add JAWSM

### DIFF
--- a/lib/agents/jawsm.js
+++ b/lib/agents/jawsm.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const fs = require("fs");
+const runtimePath = require("../runtime-path");
+const ConsoleAgent = require("../ConsoleAgent");
+
+const errorExp = /^RuntimeException: Uncaught (.+?): (.+)$/m;
+
+class JawsmAgent extends ConsoleAgent {
+  constructor(options) {
+    super(options);
+
+    this.args.unshift("--test262");
+  }
+
+  async evalScript(code, options = {}) {
+    return super.evalScript(code, options);
+  }
+
+  parseError(str) {
+    const match = str.match(errorExp);
+
+    if (!match) return null;
+
+    return {
+      name: match[1],
+      message: match[2],
+      stack: [],
+    };
+  }
+}
+
+JawsmAgent.runtime = fs.readFileSync(runtimePath.for("jawsm"), "utf8");
+
+module.exports = JawsmAgent;

--- a/runtimes/jawsm.js
+++ b/runtimes/jawsm.js
@@ -1,0 +1,26 @@
+var $262 = {
+  global: globalThis,
+  gc() {
+    throw new Test262Error("gc() not yet supported.");
+  },
+  createRealm(options) {
+    throw new Test262Error("createRealm() not yet supported.");
+  },
+  evalScript(code) {
+    throw new Test262Error("evalScript() not yet supported.");
+  },
+  getGlobal(name) {
+    return this.global[name];
+  },
+  setGlobal(name, value) {
+    this.global[name] = value;
+  },
+  destroy() {
+    /* noop */
+  },
+  IsHTMLDDA: {},
+  source: $SOURCE,
+  get agent() {
+    throw new Test262Error("agent.* not yet supported.");
+  },
+};


### PR DESCRIPTION
I still get a lot more failures with this than I would have expected, but I'm pretty sure it's the problem with JAWSM not implementing enough to run the standard harness for most tests, cause some of the tests indeed pass